### PR TITLE
Upgrade GitPython to 2.1.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     provides = 'sapling',
     install_requires = (
       'gitdb >= 0.5.1',
-      'GitPython > 0.2, < 0.4',
+      'GitPython >= 2.1.8',
     ),
 
     packages = [ 'saplib', 'sapversion' ],


### PR DESCRIPTION
GitPython < 2.1.8 is not compatible with git >= 2.15. This causes an error when running sapling:
```
root@56dd73209192:/sapling# git sap --split tests
[split = tests, branch = _sapling_split_tests_] Processing 12 commits          |
................................................................................
Traceback (most recent call last):
  File "/usr/lib/git-core/git-sap", line 6, in <module>
    exec(compile(open(__file__).read(), __file__, 'exec'))
  File "/sapling/sapling.py", line 251, in <module>
    main()
  File "/sapling/sapling.py", line 248, in main
    split(splits, options.verbose, options.dry_run)
  File "/sapling/sapling.py", line 125, in split
    tip = split.apply(branch_name, apply_listener = ProgressTracker())
  File "/sapling/saplib/split.py", line 96, in apply
    branch = lib.find(self._repo.branches,
  File "/usr/local/lib/python2.7/dist-packages/git/repo/base.py", line 237, in heads
    return Head.list_items(self)
  File "/usr/local/lib/python2.7/dist-packages/git/util.py", line 714, in list_items
    out_list.extend(cls.iter_items(repo, *args, **kwargs))
  File "/usr/local/lib/python2.7/dist-packages/git/refs/symbolic.py", line 594, in _iter_items
    for sha, rela_path in cls._iter_packed_refs(repo):
  File "/usr/local/lib/python2.7/dist-packages/git/refs/symbolic.py", line 98, in _iter_packed_refs
    raise TypeError("PackingType of packed-Refs not understood: %r" % line)
TypeError: PackingType of packed-Refs not understood: '# pack-refs with: peeled fully-peeled sorted'
```
Upgrading seems to fix. 
See: https://github.com/gitpython-developers/GitPython/issues/687